### PR TITLE
Adding attrs and sniffio as dependencies.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,3 +2,5 @@ cffi
 trio
 h11
 typeguard
+attrs
+sniffio


### PR DESCRIPTION
When trying to import syscall, this errors arise:

I send you this pull request in order to correct them.
```
ModuleNotFoundError: No module named 'attr'
ModuleNotFoundError: No module named 'sniffio'
```